### PR TITLE
Contextual matching poc

### DIFF
--- a/examples/jwplayer.amp.html
+++ b/examples/jwplayer.amp.html
@@ -36,10 +36,10 @@
         data-player-id="uoIbMPm3"
         data-media-id="BZ6tc0gy"
         data-content-search="__CONTEXTUAL__"
-        data-content-backfill=true
+        data-content-contextual=true
         data-content-recency="9D"
         data-content-backfill=true
-        layout="responsive" width="480" height="270">>
+        layout="responsive" width="480" height="270">
     </amp-jwplayer>
 </body>
 </html>

--- a/examples/jwplayer.amp.html
+++ b/examples/jwplayer.amp.html
@@ -5,7 +5,8 @@
   <title>JWPlayer AMP Example</title>
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
+  <meta property="og:title" content="title_tag" />
+  <link href='https://fonts.googleapis.com/css?family=Georgia%7COpen+Sans%7CRoboto' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-jwplayer" src="https://cdn.ampproject.org/v0/amp-jwplayer-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -29,5 +30,16 @@
       width="480" height="270">
   </amp-jwplayer>
 
+  <h3>Responsive contextual</h3>
+
+    <amp-jwplayer
+        data-player-id="uoIbMPm3"
+        data-media-id="BZ6tc0gy"
+        data-content-search="__CONTEXTUAL__"
+        data-content-backfill=true
+        data-content-recency="9D"
+        data-content-backfill=true
+        layout="responsive" width="480" height="270">>
+    </amp-jwplayer>
 </body>
 </html>

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -94,12 +94,10 @@ class AmpJWPlayer extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = this.element.ownerDocument.createElement('iframe');
-    const searchVal = this.getContextualVal();
-
     const cid = encodeURIComponent(this.contentid_);
     const pid = encodeURIComponent(this.playerid_);
     const qs = dict({
-      'search': searchVal || undefined,
+      'search': this.getContextualVal() || undefined,
       'contextual': this.contentContextual_ || undefined,
       'recency': this.contentRecency_ || undefined,
       'backfill': this.contentBackfill_ || undefined,
@@ -169,7 +167,7 @@ class AmpJWPlayer extends AMP.BaseElement {
       const title = (context.querySelector('title') || {}).textContent;
       return encodeURIComponent(ogTitle || title || '');
     }
-    return this.contentSearch_;
+    return this.contentSearch_ ;
   }
 }
 

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -78,11 +78,11 @@ class AmpJWPlayer extends AMP.BaseElement {
         el);
 
     this.contentSearch_ = el.getAttribute('data-content-search') ||
-        false;
+        '';
     this.contentContextual_ = el.getAttribute('data-content-contextual') ||
         false;
     this.contentRecency_ = el.getAttribute('data-content-recency') ||
-        false;
+        '';
     this.contentBackfill_ = el.getAttribute('data-content-backfill') ||
         false;
   }
@@ -94,11 +94,11 @@ class AmpJWPlayer extends AMP.BaseElement {
     const search = this.contentSearch_ ?
       'search=' + encodeURIComponent(this.contentSearch_) : '';
     const contextual = this.contentContextual_ ?
-      'contextual=' + encodeURIComponent(this.contentContextual_) : '';
+      'contextual=' + encodeURIComponent(this.contentContextual_.toString()) : '';
     const recency = this.contentRecency_ ?
       'recency=' + encodeURIComponent(this.contentRecency_) : '';
     const backfill = this.contentBackfill_ ?
-      'backfill=' + encodeURIComponent(this.contentBackfill_) : '';
+      'backfill=' + encodeURIComponent(this.contentBackfill_.toString()) : '';
     const contextualParams = [search, contextual, recency, backfill]
         .filter(e => !!e).join('&');
     const qsParams = contextualParams ? '?' + contextualParams : '';

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -78,13 +78,13 @@ class AmpJWPlayer extends AMP.BaseElement {
         el);
 
     this.contentSearch_ = el.getAttribute('data-content-search') ||
-      false;
+        false;
     this.contentContextual_ = el.getAttribute('data-content-contextual') ||
-      false;
+        false;
     this.contentRecency_ = el.getAttribute('data-content-recency') ||
-      false;
+        false;
     this.contentBackfill_ = el.getAttribute('data-content-backfill') ||
-      false;
+        false;
   }
 
 

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -94,7 +94,8 @@ class AmpJWPlayer extends AMP.BaseElement {
     const search = this.contentSearch_ ?
       'search=' + encodeURIComponent(this.contentSearch_) : '';
     const contextual = this.contentContextual_ ?
-      'contextual=' + encodeURIComponent(this.contentContextual_.toString()) : '';
+      'contextual='
+        + encodeURIComponent(this.contentContextual_.toString()) : '';
     const recency = this.contentRecency_ ?
       'recency=' + encodeURIComponent(this.contentRecency_) : '';
     const backfill = this.contentBackfill_ ?

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { isLayoutSizeDefined } from '../../../src/layout';
-import { removeElement } from '../../../src/dom';
-import { userAssert } from '../../../src/log';
+import {isLayoutSizeDefined} from '../../../src/layout';
+import {removeElement} from '../../../src/dom';
+import {userAssert} from '../../../src/log';
 
 class AmpJWPlayer extends AMP.BaseElement {
 
@@ -64,35 +64,45 @@ class AmpJWPlayer extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    const el = this.element;
     this.contentid_ = userAssert(
-      (this.element.getAttribute('data-playlist-id') ||
-        this.element.getAttribute('data-media-id')),
-      'Either the data-media-id or the data-playlist-id ' +
-      'attributes must be specified for <amp-jwplayer> %s',
-      this.element);
+        (el.getAttribute('data-playlist-id') ||
+        el.getAttribute('data-media-id')),
+        'Either the data-media-id or the data-playlist-id ' +
+        'attributes must be specified for <amp-jwplayer> %s',
+        el);
 
     this.playerid_ = userAssert(
-      this.element.getAttribute('data-player-id'),
-      'The data-player-id attribute is required for <amp-jwplayer> %s',
-      this.element);
-    
-    this.contentSearch_ = this.element.getAttribute('data-content-search') || false;
-    this.contentContextual_ = this.element.getAttribute('data-content-contextual') || false;
-    this.contentRecency_ = this.element.getAttribute('data-content-recency') || false;
-    this.contentBackfill_ = this.element.getAttribute('data-content-backfill') || false;
+        el.getAttribute('data-player-id'),
+        'The data-player-id attribute is required for <amp-jwplayer> %s',
+        el);
+
+    this.contentSearch_ = el.getAttribute('data-content-search') ||
+      false;
+    this.contentContextual_ = el.getAttribute('data-content-contextual') ||
+      false;
+    this.contentRecency_ = el.getAttribute('data-content-recency') ||
+      false;
+    this.contentBackfill_ = el.getAttribute('data-content-backfill') ||
+      false;
   }
 
 
   /** @override */
   layoutCallback() {
     const iframe = this.element.ownerDocument.createElement('iframe');
-    const contentSearch = this.contentSearch_ ? 'search=' + encodeURIComponent(this.contentSearch_) : '';
-    const contentContextual = this.contentContextual_ ? 'contextual=' + encodeURIComponent(this.contentContextual_) : '';
-    const contentRecency = this.contentRecency_ ? 'recency=' + encodeURIComponent(this.contentRecency_) : '';
-    const contentBackfill = this.contentBackfill_ ? 'backfill=' + encodeURIComponent(this.contentBackfill_) : '';
-    const contextualParams = [contentSearch, contentContextual, contentRecency, contentBackfill].filter(e => !!e).join('&');
+    const search = this.contentSearch_ ?
+      'search=' + encodeURIComponent(this.contentSearch_) : '';
+    const contextual = this.contentContextual_ ?
+      'contextual=' + encodeURIComponent(this.contentContextual_) : '';
+    const recency = this.contentRecency_ ?
+      'recency=' + encodeURIComponent(this.contentRecency_) : '';
+    const backfill = this.contentBackfill_ ?
+      'backfill=' + encodeURIComponent(this.contentBackfill_) : '';
+    const contextualParams = [search, contextual, recency, backfill]
+        .filter(e => !!e).join('&');
     const qsParams = contextualParams ? '?' + contextualParams : '';
-    
+
     const src = 'https://content.jwplatform.com/players/' +
       encodeURIComponent(this.contentid_) + '-' +
       encodeURIComponent(this.playerid_) + '.html' +
@@ -113,7 +123,7 @@ class AmpJWPlayer extends AMP.BaseElement {
       // The /players page can respond to "play" and "pause" commands from the
       // iframe's parent
       this.iframe_.contentWindow./*OK*/postMessage('pause',
-        'https://content.jwplatform.com');
+          'https://content.jwplatform.com');
     }
   }
 
@@ -140,7 +150,7 @@ class AmpJWPlayer extends AMP.BaseElement {
     placeholder.setAttribute('referrerpolicy', 'origin');
     if (placeholder.hasAttribute('aria-label')) {
       placeholder.setAttribute('alt',
-        'Loading video - ' + placeholder.getAttribute('aria-label')
+          'Loading video - ' + placeholder.getAttribute('aria-label')
       );
     } else {
       placeholder.setAttribute('alt', 'Loading video');

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -92,18 +92,14 @@ class AmpJWPlayer extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     const iframe = this.element.ownerDocument.createElement('iframe');
-    const contextualVal = !!this.contentSearch__ ?
-      this.determineContextual() : undefined;
-    const qs = {};
-    qs['search'] = !!contextualVal ?
-      encodeURIComponent(contextualVal) : undefined;
-    qs['contextual'] = !!this.contentContextual_ ?
-      encodeURIComponent(this.contentContextual_.toString()) : undefined;
-    qs['recency'] = !!this.contentRecency_ ?
-      encodeURIComponent(this.contentRecency_) : undefined;
-    qs['backfill'] = !!this.contentBackfill_ ?
-      encodeURIComponent(this.contentBackfill_.toString()) : undefined;
-
+    const searchVal = this.getContextualVal();
+    const qs = {
+      'search': searchVal || undefined,
+      'contextual': this.contentContextual_ || undefined,
+      'recency': this.contentRecency_ || undefined,
+      'backfill': this.contentBackfill_ || undefined,
+    };
+  
     const cid = encodeURIComponent(this.contentid_);
     const pid = encodeURIComponent(this.playerid_);
 
@@ -163,7 +159,7 @@ class AmpJWPlayer extends AMP.BaseElement {
   /**
   *
   */
-  determineContextual() {
+  getContextualVal() {
     if (this.contentSearch_ === '__CONTEXTUAL__') {
       const context = this.getAmpDoc().getHeadNode();
       const ogTitleElement = context.querySelector('meta[property="og:title"]');

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -15,9 +15,11 @@
  */
 
 import {addParamsToUrl} from '../../../src/url';
+import {dict} from '../../../src/utils/object';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {removeElement} from '../../../src/dom';
 import {userAssert} from '../../../src/log';
+
 
 class AmpJWPlayer extends AMP.BaseElement {
 
@@ -93,19 +95,18 @@ class AmpJWPlayer extends AMP.BaseElement {
   layoutCallback() {
     const iframe = this.element.ownerDocument.createElement('iframe');
     const searchVal = this.getContextualVal();
-    const qs = {
+
+    const cid = encodeURIComponent(this.contentid_);
+    const pid = encodeURIComponent(this.playerid_);
+    const qs = dict({
       'search': searchVal || undefined,
       'contextual': this.contentContextual_ || undefined,
       'recency': this.contentRecency_ || undefined,
       'backfill': this.contentBackfill_ || undefined,
-    };
-  
-    const cid = encodeURIComponent(this.contentid_);
-    const pid = encodeURIComponent(this.playerid_);
+    });
 
     const baseUrl = `https://content.jwplatform.com/players/${cid}-${pid}.html`;
-    const src = Object.keys(qs).length ?
-      addParamsToUrl(baseUrl, qs) : baseUrl;
+    const src = addParamsToUrl(baseUrl, qs);
 
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowfullscreen', 'true');

--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -71,7 +71,7 @@ describes.realWin('amp-jwplayer', {
     return getjwplayer({
       'data-playlist-id': '482jsTAr',
       'data-player-id': 'sDZEo0ea',
-      'data-content-search': '__CONTEXTUAL__',
+      'data-content-search': 'dog',
       'data-content-contextual': true,
       'data-content-recency': '9D',
       'data-content-backfill': true,
@@ -80,7 +80,7 @@ describes.realWin('amp-jwplayer', {
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
-          'https://content.jwplatform.com/players/482jsTAr-sDZEo0ea.html?search=__CONTEXTUAL__&contextual=true&recency=9D&backfill=true');
+          'https://content.jwplatform.com/players/482jsTAr-sDZEo0ea.html?search=dog&contextual=true&recency=9D&backfill=true');
     });
   });
   it('renders with a playlist and contextual, backfill parameters', () => {

--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -67,7 +67,7 @@ describes.realWin('amp-jwplayer', {
           'https://content.jwplatform.com/players/482jsTAr-sDZEo0ea.html');
     });
   });
-  it('renders with a playlist and search, contextual, recency, backfill parameters', () => {
+  it('renders with a playlist and all parameters', () => {
     return getjwplayer({
       'data-playlist-id': '482jsTAr',
       'data-player-id': 'sDZEo0ea',
@@ -80,7 +80,7 @@ describes.realWin('amp-jwplayer', {
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
-        'https://content.jwplatform.com/players/482jsTAr-sDZEo0ea.html?search=__CONTEXTUAL__&contextual=true&recency=9D&backfill=true');
+          'https://content.jwplatform.com/players/482jsTAr-sDZEo0ea.html?search=__CONTEXTUAL__&contextual=true&recency=9D&backfill=true');
     });
   });
   it('renders with a playlist and contextual, backfill parameters', () => {
@@ -94,7 +94,7 @@ describes.realWin('amp-jwplayer', {
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
-        'https://content.jwplatform.com/players/482jsTAr-sDZEo0ea.html?contextual=true&backfill=true');
+          'https://content.jwplatform.com/players/482jsTAr-sDZEo0ea.html?contextual=true&backfill=true');
     });
   });
   it('renders with a playlist and contextual parameter', () => {
@@ -107,7 +107,7 @@ describes.realWin('amp-jwplayer', {
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
-        'https://content.jwplatform.com/players/482jsTAr-sDZEo0ea.html?contextual=true');
+          'https://content.jwplatform.com/players/482jsTAr-sDZEo0ea.html?contextual=true');
     });
   });
 

--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -15,7 +15,7 @@
  */
 
 import '../amp-jwplayer';
-
+import {htmlFor} from '../../../../src/static-template';
 
 describes.realWin('amp-jwplayer', {
   amp: {
@@ -37,6 +37,12 @@ describes.realWin('amp-jwplayer', {
     jw.setAttribute('width', '320');
     jw.setAttribute('height', '180');
     jw.setAttribute('layout', 'responsive');
+    const html = htmlFor(doc);
+    env.sandbox.stub(env.ampdoc.getHeadNode(), 'querySelector')
+        .withArgs('meta')
+        .returns(
+            html`<meta property="og:title" content="title_tag" />`,
+        );
     doc.body.appendChild(jw);
     return jw.build().then(() => { jw.layoutCallback(); return jw; });
   }
@@ -65,6 +71,20 @@ describes.realWin('amp-jwplayer', {
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
           'https://content.jwplatform.com/players/482jsTAr-sDZEo0ea.html');
+    });
+  });
+  it('renders with a playlist and parses contextual parameter', () => {
+    return getjwplayer({
+      'data-playlist-id': '482jsTAr',
+      'data-player-id': 'sDZEo0ea',
+      'data-content-search': '__CONTEXTUAL__',
+      'data-content-contextual': true,
+    }).then(jw => {
+      const iframe = jw.querySelector('iframe');
+      expect(iframe).to.not.be.null;
+      expect(iframe.tagName).to.equal('IFRAME');
+      expect(iframe.src).to.equal(
+          'https://content.jwplatform.com/players/482jsTAr-sDZEo0ea.html?search=title_tag&contextual=true');
     });
   });
   it('renders with a playlist and all parameters', () => {
@@ -139,6 +159,8 @@ describes.realWin('amp-jwplayer', {
           'https://content.jwplatform.com/players/zzz-sDZEo0ea.html');
     });
   });
+
+  
 
   describe('createPlaceholderCallback', () => {
     it('should create a placeholder image', () => {

--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -67,6 +67,49 @@ describes.realWin('amp-jwplayer', {
           'https://content.jwplatform.com/players/482jsTAr-sDZEo0ea.html');
     });
   });
+  it('renders with a playlist and search, contextual, recency, backfill parameters', () => {
+    return getjwplayer({
+      'data-playlist-id': '482jsTAr',
+      'data-player-id': 'sDZEo0ea',
+      'data-content-search': '__CONTEXTUAL__',
+      'data-content-contextual': true,
+      'data-content-recency': '9D',
+      'data-content-backfill': true,
+    }).then(jw => {
+      const iframe = jw.querySelector('iframe');
+      expect(iframe).to.not.be.null;
+      expect(iframe.tagName).to.equal('IFRAME');
+      expect(iframe.src).to.equal(
+        'https://content.jwplatform.com/players/482jsTAr-sDZEo0ea.html?search=__CONTEXTUAL__&contextual=true&recency=9D&backfill=true');
+    });
+  });
+  it('renders with a playlist and contextual, backfill parameters', () => {
+    return getjwplayer({
+      'data-playlist-id': '482jsTAr',
+      'data-player-id': 'sDZEo0ea',
+      'data-content-contextual': true,
+      'data-content-backfill': true,
+    }).then(jw => {
+      const iframe = jw.querySelector('iframe');
+      expect(iframe).to.not.be.null;
+      expect(iframe.tagName).to.equal('IFRAME');
+      expect(iframe.src).to.equal(
+        'https://content.jwplatform.com/players/482jsTAr-sDZEo0ea.html?contextual=true&backfill=true');
+    });
+  });
+  it('renders with a playlist and contextual parameter', () => {
+    return getjwplayer({
+      'data-playlist-id': '482jsTAr',
+      'data-player-id': 'sDZEo0ea',
+      'data-content-contextual': true,
+    }).then(jw => {
+      const iframe = jw.querySelector('iframe');
+      expect(iframe).to.not.be.null;
+      expect(iframe.tagName).to.equal('IFRAME');
+      expect(iframe.src).to.equal(
+        'https://content.jwplatform.com/players/482jsTAr-sDZEo0ea.html?contextual=true');
+    });
+  });
 
   it('fails if no media is specified', () => {
     return allowConsoleError(() => { return getjwplayer({

--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -38,7 +38,7 @@ describes.realWin('amp-jwplayer', {
     jw.setAttribute('height', '180');
     jw.setAttribute('layout', 'responsive');
     const html = htmlFor(env.win.document);
-    env.sandbox.stub(env, 'getContextualVal')
+    env.sandbox.stub(env.ampdoc.getHeadNode(), 'querySelector')
         .withArgs('meta')
         .returns([
             html`<meta property="og:title" content="title_tag" />`

--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -37,12 +37,12 @@ describes.realWin('amp-jwplayer', {
     jw.setAttribute('width', '320');
     jw.setAttribute('height', '180');
     jw.setAttribute('layout', 'responsive');
-    const html = htmlFor(doc);
-    env.sandbox.stub(env.ampdoc.getHeadNode(), 'querySelector')
+    const html = htmlFor(env.win.document);
+    env.sandbox.stub(env, 'getContextualVal')
         .withArgs('meta')
-        .returns(
-            html`<meta property="og:title" content="title_tag" />`,
-        );
+        .returns([
+            html`<meta property="og:title" content="title_tag" />`
+      ]);
     doc.body.appendChild(jw);
     return jw.build().then(() => { jw.layoutCallback(); return jw; });
   }

--- a/extensions/amp-jwplayer/0.1/test/validator-amp-jwplayer.html
+++ b/extensions/amp-jwplayer/0.1/test/validator-amp-jwplayer.html
@@ -57,7 +57,7 @@
       data-player-id="BjcwyK37"
       data-media-id="BZ6tc0gy"
       data-content-search="__CONTEXTUAL__"
-      data-content-backfill=true
+      data-content-contextual=true
       data-content-recency="9D"
       data-content-backfill=true
       layout="responsive" width="160" height="90">

--- a/extensions/amp-jwplayer/0.1/test/validator-amp-jwplayer.html
+++ b/extensions/amp-jwplayer/0.1/test/validator-amp-jwplayer.html
@@ -48,5 +48,15 @@
   <amp-jwplayer
       data-player-id="aBcD1234"
       width="160" height="90">
+  <!-- Example of a valid amp-jwplayer with contextual article matching. -->
+  <amp-jwplayer
+      data-player-id="aBcD1234"
+      data-media-id="5678WxYz"
+      data-content-search="__CONTEXTUAL__"
+      data-content-backfill=true
+      data-content-recency="9D"
+      data-content-backfill=true
+      layout="responsive" width="160" height="90">
+  </amp-jwplayer>
 </body>
 </html>

--- a/extensions/amp-jwplayer/0.1/test/validator-amp-jwplayer.html
+++ b/extensions/amp-jwplayer/0.1/test/validator-amp-jwplayer.html
@@ -18,11 +18,12 @@
   Tests support for the amp-jwplayer tag.
 -->
 <!doctype html>
-<html ⚡>
+<html :zap:>
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="./regular-html-version.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <meta property="og:title" content="title_tag" />
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-jwplayer" src="https://cdn.ampproject.org/v0/amp-jwplayer-0.1.js"></script>
@@ -30,28 +31,31 @@
 <body>
   <!-- Example of a valid amp-jwplayer. -->
   <amp-jwplayer
-      data-player-id="aBcD1234"
-      data-media-id="5678WxYz"
+      data-player-id="BjcwyK37"
+      data-media-id="BZ6tc0gy"
       layout="responsive"
       width="160" height="90">
   </amp-jwplayer>
   <!-- Alternate valid example using a playlist rather than video. -->
   <amp-jwplayer
-      data-player-id="aBcD1234"
-      data-playlist-id="5678WxYz"
+      data-player-id="BjcwyK37"
+      data-playlist-id="482jsTAr"
       width="160" height="90">
+  </amp-jwplayer>
   <!-- Invalid example missing a player id. -->
   <amp-jwplayer
-      data-playerlist-id="5678WxYz"
+      data-playerlist-id="482jsTAr"
       width="160" height="90">
+  </amp-jwplayer>
   <!-- Invalid example missing playlist id or media-id. -->
   <amp-jwplayer
-      data-player-id="aBcD1234"
+      data-player-id="BjcwyK37"
       width="160" height="90">
+  </amp-jwplayer>
   <!-- Example of a valid amp-jwplayer with contextual article matching. -->
   <amp-jwplayer
-      data-player-id="aBcD1234"
-      data-media-id="5678WxYz"
+      data-player-id="BjcwyK37"
+      data-media-id="BZ6tc0gy"
       data-content-search="__CONTEXTUAL__"
       data-content-backfill=true
       data-content-recency="9D"

--- a/extensions/amp-jwplayer/amp-jwplayer.md
+++ b/extensions/amp-jwplayer/amp-jwplayer.md
@@ -67,16 +67,46 @@ Example:
 ## Attributes
 
 ##### data-player-id
+Type: String
 
 JW Platform player id. This is an 8-digit alphanumeric sequence that can be found in the [Players](https://dashboard.jwplayer.com/#/players) section in your JW Player Dashboard. (**Required**)
 
+
 ##### data-media-id
+Type: String
 
 The JW Platform media id. This is an 8-digit alphanumeric sequence that can be found in the [Content](https://dashboard.jwplayer.com/#/content) section in your JW Player Dashboard. (**Required if `data-playlist-id` is not defined.**)
 
-##### data-playlist-id
 
-The JW Platform playlist id. This is an 8-digit alphanumeric sequence that can be found in the [Playlists](https://dashboard.jwplayer.com/#/content/playlists) section in your JW Player Dashboard.  If both `data-playlist-id` and `data-media-id` are specified, `data-playlist-id` takes precedence.  (**Required if `data-media-id` is not defined.**)
+##### data-playlist-id
+Type: String
+
+The JW Platform playlist id. This is an 8-digit alphanumeric sequence that can be found in the [Playlists](https://dashboard.jwplayer.com/#/content/playlists) section in your JW Player Dashboard.  If both `data-playlist-id` and `data-media-id` are specified, `data-playlist-id` takes 
+precedence.  (**Required if `data-media-id` is not defined.**)
+
+
+##### data-content-search
+Type: String
+Denotes the type of the playlist. This is a search playlist that takes in a keyword or phrase as the search query and generates a playlist based on that search query. If contextual article matching is desired, use the value `_CONTEXTUAL_` (data-content-contextual must also be true).
+
+
+##### data-content-contextual
+Type: Boolean
+
+Enables the Player to grab the OG title (or HTML title if there is no OG title) of a given webpage and use that as the search query (required to do Contextual Article Matching).
+
+
+##### data-content-recency
+Type: String
+
+Limits the videos added into the playlist based on their age (i.e. the playlist includes videos that are max [xx] days old). In the format, `xD`, where x is a numerical value,
+
+
+##### data-content-backfill
+Type: Boolean
+
+Ensures that there is always a search result. If there are no search results for the given query, this parameter ensures that a list of trending videos are served.
+
 
 ##### common attributes
 


### PR DESCRIPTION
This pull request adds support for contextual article matching to the JW Player AMP Component.

Product requirements can be found [here](https://jwplayer.atlassian.net/browse/PBS-453)

**Implementation Details**

AMP only supports JW Player (and other media players) through iFrames. In its current state, a publisher defines two attributes - one for content ID (media or playlist ID) and one for player ID. These attributes are used to construct the iFrame src.

Contextual article matching requires additional attributes:

1.) Search Value (__CONTEXTUAL__, to retrieve the page context, or any string)
2.) Contextual (bool - whether or not search is contextual, or conduct a strict search)
3.) Backfill 
4.) Recency (time limiter)

Because the JW Player is loaded through an iFrame, the retrieval of the page context must be performed within the AMP component.

When values are not defined by the customer, they are omitted from the iFrame src and handled by the back end. 

**To Do**

- Resolve `gulp check-types` issue:
```
extensions/amp-jwplayer/0.1/amp-jwplayer.js:112: ERROR - actual parameter 2 of module$src$url.addParamsToUrl does not match formal parameter
found   : {}
required: JsonObject
      addParamsToUrl(baseUrl, qs) : baseUrl;
```

-Add test for og:title/title scraping